### PR TITLE
🐛 レンダリング失敗原因のログ出しと再試行方法変更

### DIFF
--- a/src/VRCTwitterImageLoader/twitter_image.py
+++ b/src/VRCTwitterImageLoader/twitter_image.py
@@ -12,7 +12,10 @@ df_urls_date = df_urls_date.dropna(subset=["url"])
 
 # ---- ランダム抽出 ----
 df_selected_urls = (
-    df_urls_date["url"].drop_duplicates().sample(n=image_num, replace=False).sort_index(ascending=True)
+    df_urls_date["url"]
+    .drop_duplicates()
+    .sample(n=image_num, replace=False)
+    .sort_index(ascending=True)
 )
 
 # # ---- 新着順で抽出 ----


### PR DESCRIPTION
原因の根本を潰せたわけではないが、レンダリング失敗時の条件が割り出せたので再試行ロジックが強固になった

1. 失敗時の特徴（1回目、2回目）:
  - Container height: 244px
  - iframe exists: False
  - Rendered class: False
  - Display flex: False
  - HTML: blockquote要素のまま（twitter-tweet-renderedクラスなし）
2. 成功時の特徴（3回目）:
  - Container height: 786px
  - iframe exists: True
  - Rendered class: True
  - Display flex: True
  - HTML: divに変換され、twitter-tweet-renderedクラスあり

